### PR TITLE
Fix rounded corners in XP and basic mode for Windows 11

### DIFF
--- a/theme/src/js/main.js
+++ b/theme/src/js/main.js
@@ -127,13 +127,13 @@ function earlyInit() {
     WindhawkComm.setMinSize(358, titleStyle === 'native' ? 60 : 90); // mini mode
     switch (style) {
         case 'xp':
-            WindhawkComm.extendFrame(0, 0, 0, 0);
+            WindhawkComm.extendFrame(0, 0, 0, 60);
             break;
         case 'aero':
             WindhawkComm.extendFrame(0, 0, 0, 60);
             break;
         case 'basic':
-            WindhawkComm.extendFrame(0, 0, 0, 0);
+            WindhawkComm.extendFrame(0, 0, 0, 60);
 
             if (localStorage.wmpotifyBasicTextColor) {
                 document.body.style.setProperty('--basic-pb-text', localStorage.wmpotifyBasicTextColor);


### PR DESCRIPTION
Currently there is a bug where rounded corners don't work on my Windows 11 machine in XP mode and basic mode:
<img width="405" height="113" alt="image" src="https://github.com/user-attachments/assets/29a87e90-72ab-4f6e-ac33-e6388b4d43c8" />
This is obviously wrong as the corners of the UI are obviously designed to be cutout from the window. This issue only occurs when using the WindHawk mod because without it Windows 11 forces rounded corners by default.

I have found that doing `extendFrame(0, 0, 0, 60)` instead of `extendFrame(0, 0, 0, 0)` for these modes fixes the issue:
<img width="420" height="130" alt="image" src="https://github.com/user-attachments/assets/a534726e-f04a-419e-94af-0e58fa589ab4" />

However it looks like this is using Windows 11's default corner cutouts, so it's not actually making the window translucent. I cannot find another way to make rounded corners work, it seems the only reason they work on Aero mode is because of `extendFrame` 60. This is a bit of a hack so it might not work on Windows 10.

I have tried everything to try and make the window properly translucent in the WindHawk mod, including forking it and messing with the WndProc but it doesn't want to play ball, so this is the next best thing I can do. If anyone can figure out a better solution I would love to see it.